### PR TITLE
RuntimeError occurs when Nick is set to ENV['USER']

### DIFF
--- a/ndk/config.rb
+++ b/ndk/config.rb
@@ -506,9 +506,10 @@ module Nadoka
           else
             if m = msgobj[$1.intern]
               if m.respond_to?(:force_encoding)
-                m.force_encoding(Encoding::ASCII_8BIT)
+                m.dup.force_encoding(Encoding::ASCII_8BIT)
+              else
+                m
               end
-              m
             else
               "!!unknown attribute: #{$1}!!"
             end


### PR DESCRIPTION
RuntimeError occurs when Nick is set to ENV['USER'].

```
14/01/16-16:22:09 [NDK] Exception RuntimeError - can't modify frozen String
14/01/16-16:22:09 [NDK] -- backtrace --
14/01/16-16:22:09 [NDK] | /usr/home/shugo/nadoka/ndk/config.rb:509:in `force_enc
oding'
14/01/16-16:22:09 [NDK] | /usr/home/shugo/nadoka/ndk/config.rb:509:in `block in 
log_format_message'
14/01/16-16:22:09 [NDK] | /usr/home/shugo/nadoka/ndk/config.rb:486:in `gsub'
14/01/16-16:22:09 [NDK] | /usr/home/shugo/nadoka/ndk/config.rb:486:in `log_forma
t_message'
14/01/16-16:22:09 [NDK] | /usr/home/shugo/nadoka/ndk/config.rb:467:in `log_forma
t'
14/01/16-16:22:09 [NDK] | /usr/home/shugo/nadoka/ndk/logger.rb:32:in `log_format
'
14/01/16-16:22:09 [NDK] | /usr/home/shugo/nadoka/ndk/logger.rb:69:in `logging'
14/01/16-16:22:09 [NDK] | /usr/home/shugo/nadoka/ndk/logger.rb:230:in `clog_msgo
bj'
14/01/16-16:22:09 [NDK] | /usr/home/shugo/nadoka/ndk/logger.rb:259:in `logging'
14/01/16-16:22:09 [NDK] | /usr/home/shugo/nadoka/ndk/server.rb:670:in `send_to_c
lients_otherwise'
14/01/16-16:22:09 [NDK] | /usr/home/shugo/nadoka/ndk/client.rb:237:in `send_from
_client'
14/01/16-16:22:09 [NDK] | /usr/home/shugo/nadoka/ndk/client.rb:57:in `start'
14/01/16-16:22:09 [NDK] | /usr/home/shugo/nadoka/ndk/server.rb:368:in `block (2 
levels) in start_clients_thread'
14/01/16-16:22:09 [NDK] Client Shugo Maeda@<my IP address> disconnected.
```

log_format_message should copy m before calling force_encoding to avoid `RuntimeError - can't modify f
rozen String' when Nick is set to ENV['USER'], which is frozen.
