### PR TITLE
add --pid option

### DIFF
--- a/nadoka.rb
+++ b/nadoka.rb
@@ -100,7 +100,7 @@ if daemon
 end
 
 if pidfile
-  open(pidfile, "w") {|f| f.puts Process.pid.to_s }
+  open(pidfile, "w") {|f| f.puts Process.pid }
 end
 
 begin


### PR DESCRIPTION
In order to send signals easily, add --pid option which stores process pid into file.
We can send signals like that:

```
$ ruby ./nadoka.rb -r ./nadokarc --pid ./pid/nadoka.pid
$ kill -s QUIT `cat ./pid/nadoka.pid`
```

This option is very useful when running nadoka with monit.
http://mmonit.com/monit/
